### PR TITLE
Write TDB2 fields in alphabetical order

### DIFF
--- a/filetypes/TDB2/TDB2Record.js
+++ b/filetypes/TDB2/TDB2Record.js
@@ -1,3 +1,6 @@
+const TDB2Table = require('./TDB2Table');
+const TDB2Field = require('./TDB2Field');
+
 class TDB2Record {
     constructor() {
         this[Symbol.toStringTag] = 'TDB2Record';
@@ -25,59 +28,79 @@ class TDB2Record {
     };
 
     // Returns a deep copy of the current record
-    deepCopyRecord(record = null, cache = new WeakMap()) {
-        // If this is the highest level call, initialize record to the current record
-        if(record === null)
-        {
-            record = this;
+    deepCopyRecord(record = null, cache = new WeakMap(), isTopLevel = true) {
+        if (record === null) record = this;
+        if (typeof record !== 'object') return record;
+        if (record instanceof Buffer) return Buffer.from(record);
+        if (cache.has(record)) return cache.get(record);
+    
+        if (record instanceof TDB2Record) {
+            const copy = new TDB2Record();
+            copy._fields = {};
+            cache.set(record, copy);
+            for (const key in record._fields) {
+                copy._fields[key] = this.deepCopyRecord(record._fields[key], cache, false);
+            }
+            copy._index = record._index;
+            if (isTopLevel) {
+                return new Proxy(copy, {
+                    get: function (target, prop, receiver) {
+                        return target._fields[prop] !== undefined ? target._fields[prop].value : target[prop] !== undefined ? target[prop] : null;
+                    },
+                    set: function (target, prop, receiver) {
+                        if (target._fields[prop] !== undefined) {
+                            target._fields[prop].value = receiver;
+                        } else {
+                            target[prop] = receiver;
+                        }
+                        return true;
+                    }
+                });
+            }
+            return copy;
         }
-        
-        if (typeof record !== 'object') {
-            return record;
+    
+        if (record instanceof TDB2Table) {
+            const copy = new TDB2Table();
+            cache.set(record, copy);
+            copy._type = record._type;
+            copy._name = record._name;
+            copy._offset = record._offset;
+            copy._unknown1 = record._unknown1;
+            copy._unknown2 = record._unknown2;
+            copy._records = record._records.map(r => this.deepCopyRecord(r, cache, false));
+            copy._rawKey = record._rawKey;
+            copy._numEntriesRaw = record._numEntriesRaw;
+            copy._isSubTable = record._isSubTable;
+            copy._parentInfo = record._parentInfo;
+            copy._fieldDefinitions = record._fieldDefinitions;
+            return copy;
         }
-
-        // Handle Buffer objects (used in TDB2Field.raw)
-        if (record instanceof Buffer) {
-            return Buffer.from(record);
+    
+        if (record instanceof TDB2Field) {
+            const copy = new TDB2Field();
+            cache.set(record, copy);
+            copy._key = record._key;
+            copy._rawKey = record._rawKey;
+            copy._type = record._type;
+            copy._length = record._length;
+            copy._raw = record._raw ? Buffer.from(record._raw) : null;
+            copy._value = record._value ? this.deepCopyRecord(record._value, cache, false) : null;
+            copy._isChanged = record._isChanged;
+            return copy;
         }
-
-        // Handle circular references
-        if (cache.has(record)) {
-            return cache.get(record);
-        }
-
-        // Create new instance with proper prototype
+    
         const proto = Object.getPrototypeOf(record);
         const copy = Object.create(proto);
         cache.set(record, copy);
-
-        // Copy all property descriptors
         const descriptors = Object.getOwnPropertyDescriptors(record);
         for (const [key, descriptor] of Object.entries(descriptors)) {
             const newDescriptor = { ...descriptor };
             if ('value' in descriptor) {
-                newDescriptor.value = this.deepCopyRecord(descriptor.value, cache);
+                newDescriptor.value = this.deepCopyRecord(descriptor.value, cache, false);
             }
             Object.defineProperty(copy, key, newDescriptor);
         }
-
-        // Re-apply Proxy if it's a TDB2Record
-        if (record instanceof TDB2Record) {
-            return new Proxy(copy, {
-                get: function (target, prop, receiver) {
-                    return target.fields[prop] !== undefined ? target.fields[prop].value : target[prop] !== undefined ? target[prop] : null;
-                },
-                set: function (target, prop, receiver) {
-                    if (target.fields[prop] !== undefined) {
-                        target.fields[prop].value = receiver;
-                    } else {
-                        target[prop] = receiver;
-                    }
-                    return true;
-                }
-            });
-        }
-
         return copy;
     }
 };

--- a/filetypes/TDB2/TDB2Table.js
+++ b/filetypes/TDB2/TDB2Table.js
@@ -1,5 +1,4 @@
 const utilService = require('../../services/utilService');
-const TDB2Record = require('./TDB2Record');
 
 class TDB2Table {
     constructor() {
@@ -125,6 +124,20 @@ class TDB2Table {
 
         // Update table's entry count
         this.numEntries++;
+    }
+
+    // Removes a record from the table
+    removeRecord(index) {
+        // Find the record to remove (we do it this way instead of just assuming records[index] to accomodate table 5 records since their indices are keyed)
+        const recordIndex = this._records.findIndex(record => record.index === index);
+
+        // If the record is found, remove it
+        if (recordIndex !== -1) {
+            this._records.splice(recordIndex, 1);
+
+            // Update table's entry count
+            this.numEntries--;
+        }
     }
 };
 

--- a/streams/TDB2/TDB2Parser.js
+++ b/streams/TDB2/TDB2Parser.js
@@ -55,6 +55,7 @@ class TDB2Parser extends FileParser {
                 record.index = utilService.readModifiedLebCompressedInteger(lebBuf);
                 if(table.unknown2 === 0x2)
                 {
+                    console.log(`Processing record at index ${record.index}`);
                     // Read LEB number for compressed byte size
                     this.bytes(0x1, (numBytesBuf) => {
                         this._readLebNumber(numBytesBuf, (lebBytesBuf) => {
@@ -89,6 +90,7 @@ class TDB2Parser extends FileParser {
     _onDecompressedTableFieldStart(recordParser, record, table)
     {
         let field = new TDB2Field();
+        console.log(recordParser.offset.toString(16));
         field.rawKey = recordParser.readBytes(4);
         field.key = utilService.getUncompressedTextFromSixBitCompression(field.rawKey.slice(0, 3));
         field.type = field.rawKey.slice(3).readUInt8(0);
@@ -99,7 +101,7 @@ class TDB2Parser extends FileParser {
             case FIELD_TYPE_INT:
                 field.raw = utilService.writeModifiedLebCompressedInteger(utilService.parseModifiedLebEncodedNumber(recordParser));
                 record.fields[field.key] = field;
-                if(field.key === 'UNWI')
+                if(field.key === 'UNWI' && recordParser.buffer[recordParser.offset] === 0)
                 {
                     field.raw = Buffer.concat([field.raw, recordParser.readBytes(1)]);
                     record.fields[field.key] = field;
@@ -138,6 +140,7 @@ class TDB2Parser extends FileParser {
                 record.fields[field.key] = field;
                 return this._checkCompressedTableRecordEnd(record, table, recordParser);
             default:
+                //console.log(recordParser.offset);
                 console.warn(`Unsupported field type: 0x${field.type.toString(16)} at index 0x${this.currentBufferIndex.toString(16)}`);
         }
     };

--- a/streams/TDB2/TDB2Writer.js
+++ b/streams/TDB2/TDB2Writer.js
@@ -31,7 +31,10 @@ class TDB2Writer extends Readable {
                 // If the table is not a compressed record storage table, write the record data normally
                 if(table.unknown2 !== 0x2)
                 {
-                    Object.keys(record.fields).map((fieldKey) => {
+                    // Write the fields in alphabetical order
+                    const sortedFields = Object.keys(record.fields).sort();
+                    
+                    sortedFields.map((fieldKey) => {
                         const field = record.fields[fieldKey];
                         // Write the field key
                         this.push(field.rawKey);
@@ -64,7 +67,10 @@ class TDB2Writer extends Readable {
                     decompressedBufs.push(Buffer.from(utilService.compress6BitString("CHVI")));
                     decompressedBufs.push(Buffer.from([0x03]));
 
-                    Object.keys(record.fields).map((fieldKey) => {
+                    // Write the fields in alphabetical order
+                    const sortedFields = Object.keys(record.fields).sort();
+
+                    sortedFields.map((fieldKey) => {
                         const field = record.fields[fieldKey];
                         decompressedBufs.push(field.rawKey);
 

--- a/tests/e2e/TDB2Table5Tests.spec.js
+++ b/tests/e2e/TDB2Table5Tests.spec.js
@@ -70,6 +70,27 @@ it('M24 Added Record Test', () => {
         });
     });
 });
+
+it('M24 Removed Record Test', () => {
+    const m24Helper = new MaddenRosterHelper();
+    m24Helper.load(m24Path).then(() => {
+        const originalTableLength = m24Helper.file.CVPM.numEntries;
+
+        // Remove first record (Geno Smith - key 112)
+        m24Helper.file.CVPM.removeRecord(112);
+
+        m24Helper.save("tests/data/WriteTest_RemovedRecordM24_ROSTER-Official").then(() => {
+            const m24Helper2 = new MaddenRosterHelper();
+            m24Helper2.load("tests/data/WriteTest_RemovedRecordM24_ROSTER-Official").then(() => {
+                // Ensure the entry has been removed
+                expect(m24Helper2.file.CVPM.records.numEntries).to.equal(originalTableLength - 1);
+                expect(m24Helper2.file.CVPM.records.find((record) => {
+                    return record.index === 112;
+                })).to.equal(undefined);
+            });
+        });
+    });
+});
  
 
 it('M25 Helper test', () => {
@@ -134,6 +155,27 @@ it('M25 Added Record Test', () => {
 
                 // Ensure that the original record remains intact
                 expect(m25Helper2.file.PLEX.records[0].fields['ASNM'].value).to.equal('SmithGeno_112');
+            });
+        });
+    });
+});
+
+it('M25 Removed Record Test', () => {
+    const m25Helper = new MaddenRosterHelper();
+    m25Helper.load(m25Path).then(() => {
+        const originalTableLength = m25Helper.file.PLEX.numEntries;
+
+        // Remove first record (Geno Smith - key 112)
+        m25Helper.file.PLEX.removeRecord(112);
+
+        m25Helper.save("tests/data/WriteTest_RemovedRecordM25_ROSTER-Official").then(() => {
+            const m25Helper2 = new MaddenRosterHelper();
+            m25Helper2.load("tests/data/WriteTest_RemovedRecordM25_ROSTER-Official").then(() => {
+                // Ensure the entry has been removed
+                expect(m25Helper2.file.PLEX.records.numEntries).to.equal(originalTableLength - 1);
+                expect(m25Helper2.file.PLEX.records.find((record) => {
+                    return record.index === 112;
+                })).to.equal(undefined);
             });
         });
     });


### PR DESCRIPTION
Modified the TDB2 writer to ensure that a record's fields are always written in alphabetical order. This prevents an issue where the game does not read certain fields properly if all records don't have fields written in the same order.